### PR TITLE
Fix white backgrounds on new queue page

### DIFF
--- a/src/styles/queue.scss
+++ b/src/styles/queue.scss
@@ -36,6 +36,15 @@
 	.queue-controls .text-link:hover {
 		color: $link-color-hover;
 	}
+	.queue-item {
+		background-color: $background-color-lighter;
+		.series-title {
+			color: $link-color;
+		}
+		.series-title:hover {
+			color: $link-color-hover
+		}
+	}
 }
 
 /* this looks dumb, but crunchyroll has this set to !important, so the only way to override it is to have a more specific selector then they do */


### PR DESCRIPTION
Fixes the white background on the new queue page
Fix #8 

Before:
![image](https://user-images.githubusercontent.com/26328586/72940165-b4496200-3d44-11ea-94b3-f228d5349d64.png)

After:
![image](https://user-images.githubusercontent.com/26328586/72940178-bc090680-3d44-11ea-83a8-15307adaf329.png)
